### PR TITLE
fix(engine): avoid critical-severity false positives on missing resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wafpass-core"
-version = "1.0.0"
+version = "1.1.2"
 description = "WAF++ PASS – IaC compliance engine, CLI, and result schema for the WAF++ framework"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import pytest
 
-from wafpass.engine import SkipAssertion, evaluate_assertion, get_nested, _find_matching_blocks
+from wafpass.engine import SkipAssertion, evaluate_assertion, get_nested, _find_matching_blocks, _provider_present, _run_check, run_controls
 from wafpass.iac.base import IaCBlock, IaCState
-from wafpass.models import Assertion, Check, Scope
+from wafpass.models import Assertion, Check, Control, Scope
 from wafpass.parser import TerraformBlock, TerraformState
 
 
@@ -442,3 +442,116 @@ def test_find_matching_blocks_provider_scope_prefers_provider_name() -> None:
     scope = Scope(block_type="provider", provider_name="aws", resource_types=["google"])
     blocks = _find_matching_blocks(scope, state)
     assert [b.address for b in blocks] == ["provider.aws"]
+
+
+# ── provider presence filtering ───────────────────────────────────────────────
+
+
+class TestProviderPresent:
+    def test_any_provider_is_always_present(self) -> None:
+        state = IaCState(providers=[])
+        assert _provider_present("any", state) is True
+
+    def test_explicit_provider_present(self) -> None:
+        state = IaCState(providers=[
+            IaCBlock(block_type="provider", type="aws", name="", address="provider.aws", attributes={}, raw={}),
+        ])
+        assert _provider_present("aws", state) is True
+
+    def test_missing_provider_not_present(self) -> None:
+        state = IaCState(providers=[
+            IaCBlock(block_type="provider", type="aws", name="", address="provider.aws", attributes={}, raw={}),
+        ])
+        assert _provider_present("azurerm", state) is False
+
+    def test_no_providers_defaults_to_present(self) -> None:
+        """When a plugin does not populate providers (CDK/Pulumi or implicit Terraform
+        defaults), do not silently drop checks.
+        """
+        state = IaCState(providers=[])
+        assert _provider_present("aws", state) is True
+
+
+def test_run_check_returns_empty_when_no_matching_blocks() -> None:
+    """No matching resources means no per-check finding; control-level SKIP is shown elsewhere."""
+    state = IaCState()
+    check = Check(
+        id="waf-rel-010.tf.aws.cloudwatch-slo-alarm",
+        engine="terraform",
+        provider="aws",
+        automated=True,
+        severity="critical",
+        title="AWS CloudWatch alarm must be configured for SLO availability monitoring",
+        scope=Scope(block_type="resource", resource_types=["aws_cloudwatch_metric_alarm"]),
+        assertions=[Assertion(attribute="alarm_name", op="not_empty")],
+        on_fail="violation",
+        remediation="r",
+    )
+    control = Control(
+        id="WAF-REL-010",
+        title="SLA & SLO Definition Documented",
+        pillar="reliability",
+        severity="critical",
+        category="reliability-governance",
+        description="d",
+        checks=[check],
+    )
+    results = _run_check(check, control, state)
+    assert results == []
+
+
+def test_run_controls_skips_checks_for_absent_providers() -> None:
+    """AWS-only config should not emit Azure/GCP checks."""
+    state = IaCState(
+        providers=[
+            IaCBlock(block_type="provider", type="aws", name="", address="provider.aws", attributes={}, raw={}),
+        ],
+        resources=[
+            IaCBlock(
+                block_type="resource",
+                type="aws_cloudwatch_metric_alarm",
+                name="slo",
+                address="aws_cloudwatch_metric_alarm.slo",
+                attributes={"alarm_name": "slo-errors"},
+                raw={},
+            ),
+        ],
+    )
+    aws_check = Check(
+        id="waf-rel-010.tf.aws.cloudwatch-slo-alarm",
+        engine="terraform",
+        provider="aws",
+        automated=True,
+        severity="critical",
+        title="AWS CloudWatch alarm",
+        scope=Scope(block_type="resource", resource_types=["aws_cloudwatch_metric_alarm"]),
+        assertions=[Assertion(attribute="alarm_name", op="not_empty")],
+        on_fail="violation",
+        remediation="r",
+    )
+    azure_check = Check(
+        id="waf-rel-010.tf.azurerm.monitor-metric-alert-slo",
+        engine="terraform",
+        provider="azurerm",
+        automated=True,
+        severity="critical",
+        title="Azure Monitor metric alert",
+        scope=Scope(block_type="resource", resource_types=["azurerm_monitor_metric_alert"]),
+        assertions=[Assertion(attribute="name", op="not_empty")],
+        on_fail="violation",
+        remediation="r",
+    )
+    control = Control(
+        id="WAF-REL-010",
+        title="SLA & SLO Definition Documented",
+        pillar="reliability",
+        severity="critical",
+        category="reliability-governance",
+        description="d",
+        checks=[aws_check, azure_check],
+    )
+    results = run_controls([control], state, engine_name="terraform")
+    assert len(results) == 1
+    check_ids = {r.check_id for r in results[0].results}
+    assert aws_check.id in check_ids
+    assert azure_check.id not in check_ids

--- a/wafpass/__init__.py
+++ b/wafpass/__init__.py
@@ -26,7 +26,7 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("wafpass-core")
 except PackageNotFoundError:
-    __version__ = "1.0.0"
+    __version__ = "1.1.2"
 
 __name_full__ = "WAF++ PASS"
 

--- a/wafpass/engine.py
+++ b/wafpass/engine.py
@@ -407,6 +407,25 @@ def _find_matching_blocks(scope: Scope, tf: IaCState) -> list[IaCBlock]:
     return []
 
 
+def _provider_present(provider: str, tf: IaCState) -> bool:
+    """Return True if a provider block of the given type exists in the state.
+
+    When no provider blocks were parsed (e.g. CDK/Pulumi or Terraform with
+    implicit default providers) this returns True so checks are not silently
+    dropped.  Aliases are ignored; the base provider type is what matters.
+
+    The special provider value ``any`` means the check applies to every
+    provider and is always considered present.
+    """
+    if provider == "any":
+        return True
+    if not tf.providers:
+        # No explicit provider information available — run the check and let
+        # resource-type matching decide the outcome.
+        return True
+    return any(p.type == provider for p in tf.providers)
+
+
 def _run_check(
     check: Check, control: Control, tf: IaCState
 ) -> list[CheckResult]:
@@ -415,19 +434,9 @@ def _run_check(
     matching_blocks = _find_matching_blocks(check.scope, tf)
 
     if not matching_blocks:
-        results.append(
-            CheckResult(
-                check_id=check.id,
-                check_title=check.title,
-                control_id=control.id,
-                severity=check.severity,
-                status="SKIP",
-                resource="(none)",
-                message="No matching resources found in Terraform configuration.",
-                remediation=check.remediation,
-                example=check.example,
-            )
-        )
+        # No matching resources: skip the check without emitting a per-check
+        # finding.  The control-level report still shows SKIP when every check
+        # in the control returns an empty result list.
         return results
 
     for block in matching_blocks:
@@ -513,6 +522,11 @@ def run_controls(
         for check in control.checks:
             if engine_name is not None and check.engine != engine_name:
                 # Skip checks that target a different IaC engine.
+                continue
+            if not _provider_present(check.provider, tf):
+                # The configured IaC does not declare this provider, so the
+                # check is irrelevant for this scan (e.g. Azure checks against
+                # an AWS-only Terraform configuration).
                 continue
             check_results = _run_check(check, control, tf)
             all_check_results.extend(check_results)


### PR DESCRIPTION
  Previously, checks like WAF-REL-010 emitted SKIP results with control-level
  severity (critical) when the target resource type was not present, causing
  downstream reports to flag them as critical findings.

  Changes:
  - _run_check now returns an empty result list when no blocks match.
  - run_controls skips checks whose provider is not declared in the IaC state.
  - provider: any is always evaluated.
  - Add engine tests for provider filtering and empty-match behavior.
  - Bump version to 1.1.2.